### PR TITLE
tab: return to first element

### DIFF
--- a/src/mg-plus-extensions.js
+++ b/src/mg-plus-extensions.js
@@ -153,8 +153,16 @@
           classie.addClass(selector, "active");
           selector.setAttribute("data-active", "true");
           var targetToShow = selector.getAttribute("data-target");
-          if (targetToShow)
+          if (targetToShow) {
             document.getElementById(targetToShow).style.display = "block";
+          } else {
+            // return to first element
+            items[0].setAttribute("data-active", "true");
+            classie.addClass(items[0], "active");
+            var targetToShow = items[0].getAttribute("data-target");
+            if (targetToShow)
+              document.getElementById(targetToShow).style.display = "block";
+          }
         }
       });
     }


### PR DESCRIPTION
On some occasions, when we are in the last element of the tab, all items have display none, which causes discomfort in those who are navigating. In this modification, if this scenario occurs, the first element of the items will be displayed.